### PR TITLE
add more tests `

### DIFF
--- a/tests/zhwoverride.sh
+++ b/tests/zhwoverride.sh
@@ -37,12 +37,44 @@ if [ $rc != 0 ]; then
 	exit 3
 fi
 
+
+zbrew -c install zhw110
+rc=$?
+if [ $rc != 0 ]; then
+        echo "zbrew install failed with rc:$rc" >&2
+        exit 5
+fi
+
+zbrew smpreceiveptf zhw110 ${ZBREW_HLQ}ZHWZ110.MCSPTF2  
+rc=$?
+if [ $rc != 0 ]; then
+        echo "zbrew receive ptf from z/os file failed with rc:$rc" >&2
+        exit 4
+fi
+
+zbrew update zhw110
+rc=$?
+if [ $rc != 0 ]; then
+        echo "zbrew update of zhw110 failed with rc:$rc" >&2
+        exit 4
+fi
+
+
 zbrew configure zhw110
 rc=$?
 if [ $rc != 0 ]; then
-	echo "zbrew configure failed with rc:$rc" >&2
-	exit 4
+        echo "zbrew configure failed with rc:$rc" >&2
+        exit 4
 fi
+
+
+zbrew uninstall zhw110
+rc=$?
+if [ $rc != 0 ]; then
+        echo "zbrew uninstall failed with rc:$rc" >&2
+        exit 6
+fi
+
 
 #
 # 

--- a/zhw110.bom
+++ b/zhw110.bom
@@ -2,6 +2,8 @@ LICENSE
 README.md
 zhw110/smphold/zhw110.hold
 zhw110/smpmcs/zhw110.mcs
+zhw110/smpmcs/zhw110ptf1.mcs
+zhw110/smpmcs/zhw110ptf2.mcs
 zhw110/smprelf/hw.rexx
 zhw110/smprelf/hw1.rexx
 zhw110/smprelf/hw2.rexx

--- a/zhw110/zhw110config
+++ b/zhw110/zhw110config
@@ -18,28 +18,47 @@ zbrewpropse zhw110 install "${props}"
 #Run REXX program and trim the trailing blanks
 out=`mvscmd --pgm=IRXJCL --args='HW' --sysexec="${ZBREW_HLQ}ZHW110.SZHWSM" --systsin=dummy --systsprt=stdout --sysprint=stdout | awk '{ $1=$1; print}'`
 if [ "${out}" != 'Hello World' ]; then
-	echo "IVP of zhw110 failed. Unexpected output: ${out} received" >&2
-	exit 16
+	echo "IVP Test 1 of zhw110 failed. Unexpected output: ${out} received" >&2
+	rc=16
 else
 	echo "IVP Test 1 passed. Output generated: ${out}">&2
 fi
 
+out=`mvscmd --pgm=IRXJCL --args='HW4' --sysexec="${ZBREW_HLQ}ZHW110.SZHWSM" --systsin=dummy --systsprt=stdout --sysprint=stdout | awk '{ $1=$1; print}'`
+if [ "${out}" != 'HELLO CRAZY WORLD' ]; then
+        echo "IVP Test 2 of zhw110 failed. Unexpected output: ${out} received" >&2
+	echo "Expect this Test to FAIL if you have not run zbrew smpreceiveptf zhw110 'ZBREW.ZHWZ110.MCSPTF2'" >&2
+	echo "AND zbrew update zhw110" >&2
+	rc=16
+else
+        echo "IVP Test 2 passed. Output generated: ${out}">&2
+fi
+
+
+out=`mvscmd --pgm=IRXJCL --args='HW5' --sysexec="${ZBREW_HLQ}ZHW110.SZHWSM" --systsin=dummy --systsprt=stdout --sysprint=stdout | awk '{ $1=$1; print}'`
+if [ "${out}" != 'HELLO SUPER BAT-CRAP CRAZY WORLD' ]; then
+        echo "IVP TEST 3 of zhw110 failed. Unexpected output: ${out} received" >&2
+	echo "Expect this Test to FAIL if you have not run zbrew update zhw110" >&2
+	rc=8
+else
+        echo "IVP Test 3 passed. Output generated: ${out}">&2
+fi
 
 hw1=`${ZFSROOT}${ZFSDIR}HW1` 
 if [ "$hw1" != 'Hello World 1' ]; then
-	echo "IVP of zhw110 failed for HW1. Unexpected output: ${hw1} received" >&2
-        exit 16
+	echo "IVP Test 4 of zhw110 failed for HW1. Unexpected output: ${hw1} received" >&2
+        rc=16
 else
-	echo "IVP Test 2 passed. Output generated: ${hw1}" >&2
+	echo "IVP Test 4 passed. Output generated: ${hw1}" >&2
 fi
 
 hw2=`${ZFSROOT}${ZFSDIR}sepzfs/HW2`
 if [ "$hw2" != 'Hello World 2' ]; then
-        echo "IVP of zhw110 failed for HW2. Unexpected output: ${hw2} received" >&2
-        exit 16
+        echo "IVP Test 5 of zhw110 failed for HW2. Unexpected output: ${hw2} received" >&2
+        rc=16
 else
-	echo "IVP Test 3 passed. Output generated: ${hw2}" >&2
+	echo "IVP Test 5 passed. Output generated: ${hw2}" >&2
 fi
 
 
-exit 0
+exit $rc

--- a/zhw110/zhw110crtpkg
+++ b/zhw110/zhw110crtpkg
@@ -29,6 +29,8 @@ zbrewpropse zbrew config "${props}"
 sysin=${ZBREW_TMP}/$$.gimzip.sysin
 hlq="${ZBREW_HLQ}"
 smpmcs="${hlq}ZHWZ110.MCS"
+smpmcsptf1="${hlq}ZHWZ110.MCSPTF1"
+smpmcsptf2="${hlq}ZHWZ110.MCSPTF2"
 smphld="${hlq}ZHWZ110.HOLD"
 smppdsf="${hlq}ZHWZ110.PDS"
 smprelf="${hlq}ZHWZ110.F1"
@@ -38,6 +40,11 @@ echo "
   <FILEDEF name=\"${smpmcs}\"
            description=\"mcs file\"
            archid=\"SMPMCS\"
+           type=\"SMPPTFIN\">
+  </FILEDEF>
+  <FILEDEF name=\"${smpmcsptf1}\"
+           description=\"mcs ptf1\"
+           archid=\"SMPMCS.PTF1\"
            type=\"SMPPTFIN\">
   </FILEDEF>
   <FILEDEF name=\"${smphld}\"
@@ -53,16 +60,20 @@ echo "
 </GIMZIP>
 " >${sysin}
 
-drm -f "${smppdsf}" "${smprelf}" "${smpmcs}" "${smphld}"
+drm -f "${smppdsf}" "${smprelf}" "${smpmcs}" "${smpmcsptf1}" "${smpmcsptf2}" "${smphld}"
 dtouch -tpds "${smppdsf}"
 dtouch -tpds "${smprelf}"
 dtouch -tseq "${smpmcs}"
+dtouch -tseq "${smpmcsptf1}"
+dtouch -tseq "${smpmcsptf2}"
 dtouch -tseq "${smphld}"
 
 hfssmprelf=`a2e ${mydir}/smprelf/hw.rexx`
 hfssmprelf1=`a2e ${mydir}/smprelf/hw1.rexx`
 hfssmprelf2=`a2e ${mydir}/smprelf/hw2.rexx`
 hfssmpmcs=`a2e ${mydir}/smpmcs/zhw110.mcs`
+hfssmpmcsptf1=`a2e ${mydir}/smpmcs/zhw110ptf1.mcs`
+hfssmpmcsptf2=`a2e ${mydir}/smpmcs/zhw110ptf2.mcs`
 hfssmphld=`a2e ${mydir}/smphold/zhw110.hold`
 
 dcp "${hfssmprelf}" "${smppdsf}(HW)"
@@ -79,6 +90,8 @@ if [ $rc -gt 0 ]; then
 fi
 
 dcp "${hfssmpmcs}" "${smpmcs}"
+dcp "${hfssmpmcsptf1}" "${smpmcsptf1}"
+dcp "${hfssmpmcsptf2}" "${smpmcsptf2}"
 dcp "${hfssmphld}" "${smphld}"
 
 sysut2=`mvstmp ${hlq}S2`
@@ -96,7 +109,7 @@ if [ $rc -gt 0 ]; then
 	echo "${out}" >&2
 	exit $rc
 fi
-rm ${hfssmprelf} ${hfssmprelf1} ${hfssmprelf2} ${hfssmpmcs} ${hfssmphld} ${sysin}
-drm ${smppdsf} ${smprelf} ${smpmcs} ${smphld} ${sysut2} ${sysut3} ${sysut4}
+rm ${hfssmprelf} ${hfssmprelf1} ${hfssmprelf2} ${hfssmpmcs} ${hfssmpmcsptf1} ${hfssmpmcsptf2} ${hfssmphld} ${sysin}
+drm ${smppdsf} ${smprelf} ${smpmcs} ${smpmcsptf1} ${smphld} ${sysut2} ${sysut3} ${sysut4}
 
 exit $rc


### PR DESCRIPTION
Added additional functionality:

crtpkg will now add some PTF's into the MCS

One PTF can be applied immediately after zbrew install via zbrew update zhw110

One PTF must be received via zbrew smpreceiveptf zhw110 ${HLQ}ZHWZ110.ZBREWT.ZHWZ110.MCSPTF2 followed by zbrew update zhw110

zhwoverride test added these steps 

zbrew configure updated to account for new tests 